### PR TITLE
Fixed Component Item Missing Image

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -69,7 +69,7 @@ const App = () => {
         />
         <SectionComponent
           title="Component Initial Setup with Interface Props"
-          htmlElement={PropComponentSetup}
+          htmlElement={<PropComponentSetup/>}
         />
         <SectionComponent
           title="Python Behave"


### PR DESCRIPTION
PropComponentSetup didn't have tags which was why it
wasn't showing up so I added that and fixed bug
#24 